### PR TITLE
Rettet språkfeil, anglisismer

### DIFF
--- a/Keyed/Misc.xml
+++ b/Keyed/Misc.xml
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
   <Autosaving>Autolagring</Autosaving>
   
-  <GameStartDialog>De tre av dere våkner opp i deres kryptosøvn sarkofager til lyden av sirener og skjærende metall, Dere kommer så vidt til livredningskapslene før skipet blir revet løst.\n\nEn tid senere lander dere på denne ukjente rimverdenen.\n\nImens deler av det opprevne stjerneskipet faller rundt dere, begynner dere å lage planer for å overleve.</GameStartDialog>
+  <GameStartDialog>Dere våkner i kryptosøvnsarkofag til lyden av sirener og skingrende metall. Dere kommer dere så vidt til livredningskapslene før skipet revner fullstendig.\n\nEn stund senere lander dere på denne ukjente kloden.\n\nImens deler av det opprevne romskipet faller rundt dere, begynner dere å legge planer for å overleve.</GameStartDialog>
 
   <Colony>Koloni</Colony>
   
-  <ChangeLanguageFromMainMenu>Du kan bare endre språk via hovedmenyen.</ChangeLanguageFromMainMenu>
+  <ChangeLanguageFromMainMenu>Du kan bare endre språk fra innstillingskjermen på hovedmenyen.</ChangeLanguageFromMainMenu>
 
   <AndLower>og</AndLower>
   <DisabledLower>deaktivert</DisabledLower>
@@ -19,25 +19,25 @@
   <DevelopmentBuildLower>utviklingsutgave</DevelopmentBuildLower>
   <CompiledOn>Kompilert {0}</CompiledOn>
 
-	<MeatLabel>{0}kjøtt</MeatLabel>
+	<MeatLabel>{0} kjøtt</MeatLabel>
   <MeatDesc>Ferskt kjøtt av et {0}.</MeatDesc>
 
-  <LeatherLabel>{0}lær</LeatherLabel>
-  <LeatherDesc>Lær framstilt fra huden til et {0}.</LeatherDesc>
+  <LeatherLabel>{0} lær</LeatherLabel>
+  <LeatherDesc>Lær framstilt fra skinnet til et {0}.</LeatherDesc>
 
-  <CorpseLabel>{0}lik</CorpseLabel>
-	<CorpseDesc>Dødt lik av et {0}.</CorpseDesc>
+  <CorpseLabel>{0} lik</CorpseLabel>
+	<CorpseDesc>Lik av et {0}.</CorpseDesc>
   <DeadLabel>{0} (død)</DeadLabel>
 
 
-	<BlueprintLabelExtra> (planlagt)</BlueprintLabelExtra>
-  <FrameLabelExtra> (bygning)</FrameLabelExtra>
+	<BlueprintLabelExtra> (blåkopi)</BlueprintLabelExtra>
+  <FrameLabelExtra> (bygg)</FrameLabelExtra>
   
   <!-- For things made of stuff, e.g. "Stone bed" -->
   <!-- 0 is the nameAsStuff property under stuffProps and 1 is the label -->
-  <ThingMadeOfStuffLabel>{0}{1}</ThingMadeOfStuffLabel>
+  <ThingMadeOfStuffLabel>{0} {1}</ThingMadeOfStuffLabel>
 
-  <VariousLabel>(diverse)</VariousLabel>
+  <VariousLabel>(ulike)</VariousLabel>
 
   <!-- History events -->
   <ColonistDied>Kolonist døde</ColonistDied>


### PR DESCRIPTION
Flere orddelingsfeil og anglisismer rettet til bedre norsk, pluss noen stavefeil. Synes ordet kryptosøvnsarkofag er litt langt og kronglete å si på norsk, funker bedre i engelsk fordi man stykker opp ordene. Trenger et bedre ord for det, vi kan f.eks. bytte ut sarkofag med 'kiste' for å korte ned ordlengden og beholde betydningen, men det er sikkert ikke heilt ukontroversielt.

Endre ordet 'rimverdenen' til 'kloden', siden rimverden på engelsk er 'rhymeworld', mens rimworld betyr 'kantverden', eller 'yttergrenseverden', avhengig av hvilken betydning som legges i ordet. Det finnes ingen gode norske ord for det, og med mindre vi skal endre navnet på spillet til "kantverden", som høres fryktelig tullete ut. Ettersom ordet er uoversettelig, og egentlig bare er der for å nevne tittelen på spillet, er det best å bare bruke ordet klode i stedet, alternativt planet.
